### PR TITLE
rdma-core/ucx/openmpi: fix build on loongarch64

### DIFF
--- a/pkgs/by-name/op/openmpi/package.nix
+++ b/pkgs/by-name/op/openmpi/package.nix
@@ -102,6 +102,8 @@ stdenv.mkDerivation (finalAttrs: {
       libnl
       numactl
       pmix
+    ]
+    ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform ucx) [
       ucx
       ucc
     ]
@@ -155,8 +157,10 @@ stdenv.mkDerivation (finalAttrs: {
           [
             "mpi"
           ]
-          ++ lib.optionals stdenv.hostPlatform.isLinux [
+          ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform ucx) [
             "shmem"
+          ]
+          ++ lib.optionals stdenv.hostPlatform.isLinux [
             "osh"
           ];
         s =
@@ -204,7 +208,7 @@ stdenv.mkDerivation (finalAttrs: {
       wrapperDataFileNames = {
         part1 = [
           "mpi"
-        ] ++ lib.optionals stdenv.hostPlatform.isLinux [ "shmem" ];
+        ] ++ lib.optionals (lib.meta.availableOn stdenv.hostPlatform ucx) [ "shmem" ];
         part2 = builtins.attrNames wrapperDataSubstitutions;
       };
     in

--- a/pkgs/by-name/rd/rdma-core/package.nix
+++ b/pkgs/by-name/rd/rdma-core/package.nix
@@ -28,20 +28,30 @@ stdenv.mkDerivation (finalAttrs: {
 
   strictDeps = true;
 
-  outputs = [
-    "out"
-    "man"
-    "dev"
-  ];
+  outputs = 
+    [
+      "out"
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isLoongArch64) [
+      "man"
+    ]
+    ++ [
+      "dev"
+    ];
 
-  nativeBuildInputs = [
-    cmake
-    docutils
-    pandoc
-    pkg-config
-    python3
-    udevCheckHook
-  ];
+  nativeBuildInputs = 
+    [
+      cmake
+    ]
+    ++ lib.optionals (!stdenv.hostPlatform.isLoongArch64) [
+      docutils
+      pandoc
+    ]
+    ++ [
+      pkg-config
+      python3
+      udevCheckHook
+    ];
 
   buildInputs = [
     ethtool
@@ -51,10 +61,11 @@ stdenv.mkDerivation (finalAttrs: {
     udev
   ];
 
-  cmakeFlags = [
-    "-DCMAKE_INSTALL_RUNDIR=/run"
-    "-DCMAKE_INSTALL_SHAREDSTATEDIR=/var/lib"
-  ];
+  cmakeFlags = 
+    [
+      "-DCMAKE_INSTALL_RUNDIR=/run"
+      "-DCMAKE_INSTALL_SHAREDSTATEDIR=/var/lib"
+    ] ++ lib.optional stdenv.hostPlatform.isLoongArch64 "-DNO_MAN_PAGES=1";
 
   postPatch = ''
     substituteInPlace srp_daemon/srp_daemon.sh.in \

--- a/pkgs/by-name/uc/ucx/package.nix
+++ b/pkgs/by-name/uc/ucx/package.nix
@@ -106,11 +106,14 @@ stdenv'.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  meta = with lib; {
+  meta = {
     description = "Unified Communication X library";
     homepage = "https://www.openucx.org";
-    license = licenses.bsd3;
-    platforms = platforms.linux;
-    maintainers = [ maintainers.markuskowa ];
+    license = lib.licenses.bsd3;
+    platforms = with lib.platform; [
+      "x86_64-linux"
+      "aarch64-linux"
+    ];
+    maintainers = with lib.maintainers; [ markuskowa ];
   };
 }


### PR DESCRIPTION
1. The man pages of `rdma-core` depend on the Haskell package `pandoc`.
2. Building `ucx` on LoongArch64 is currently not supported. See: [https://github.com/openucx/ucx/issues/9873](https://github.com/openucx/ucx/issues/9873)
   We need to identify other supported platforms for building UCX to prevent blocking UCX on them. (e.g., RISC-V, PowerPC).
3. `openmpi` depends on `ucx` and `rdma-core`, so we must resolve points 1 and 2 before opening a PR to `nixos/nixpkgs`.

## Things done
test build of petsc (which include suitesparse,fftw,scalapack,mumps_mpi,superlu_dist), python3Packages.mpi4py

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform:
  - [ ] x86_64-linux
  - [ ] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- Tested, as applicable:
  - [ ] [NixOS tests] in [nixos/tests].
  - [ ] [Package tests] at `passthru.tests`.
  - [ ] Tests in [lib/tests] or [pkgs/test] for functions and "core" functionality.
- [ ] Ran `nixpkgs-review` on this PR. See [nixpkgs-review usage].
- [ ] Tested basic functionality of all binary files, usually in `./result/bin/`.
- Nixpkgs Release Notes
  - [ ] Package update: when the change is major or breaking.
- NixOS Release Notes
  - [ ] Module addition: when adding a new NixOS module.
  - [ ] Module update: when the change is significant.
- [ ] Fits [CONTRIBUTING.md], [pkgs/README.md], [maintainers/README.md] and other READMEs.

[NixOS tests]: https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests
[Package tests]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests
[nixpkgs-review usage]: https://github.com/Mic92/nixpkgs-review#usage

[CONTRIBUTING.md]: https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md
[lib/tests]: https://github.com/NixOS/nixpkgs/blob/master/lib/tests
[maintainers/README.md]: https://github.com/NixOS/nixpkgs/blob/master/maintainers/README.md
[nixos/tests]: https://github.com/NixOS/nixpkgs/blob/master/nixos/tests
[pkgs/README.md]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md
[pkgs/test]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/test

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
